### PR TITLE
feat(http): add `SameSite` attribute for both CSRF and session cookies

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -57,14 +58,15 @@ type (
 		HTTPSessionRedisWait            bool          `env:"HTTP_SESSION_REDIS_WAIT" envDefault:"true"`
 
 		// Session related configuration.
-		HTTPSessionName       string   `env:"HTTP_SESSION_NAME" envDefault:"_session"`
-		HTTPSessionProvider   string   `env:"HTTP_SESSION_PROVIDER" envDefault:"cookie"`
-		HTTPSessionExpiration int      `env:"HTTP_SESSION_EXPIRATION" envDefault:"1209600"`
-		HTTPSessionDomain     string   `env:"HTTP_SESSION_DOMAIN" envDefault:"localhost"`
-		HTTPSessionHTTPOnly   bool     `env:"HTTP_SESSION_HTTP_ONLY" envDefault:"true"`
-		HTTPSessionPath       string   `env:"HTTP_SESSION_PATH" envDefault:"/"`
-		HTTPSessionSecure     bool     `env:"HTTP_SESSION_SECURE" envDefault:"false"`
-		HTTPSessionSecrets    [][]byte `env:"HTTP_SESSION_SECRETS,required" envDefault:""`
+		HTTPSessionName       string        `env:"HTTP_SESSION_NAME" envDefault:"_session"`
+		HTTPSessionProvider   string        `env:"HTTP_SESSION_PROVIDER" envDefault:"cookie"`
+		HTTPSessionExpiration int           `env:"HTTP_SESSION_EXPIRATION" envDefault:"1209600"`
+		HTTPSessionDomain     string        `env:"HTTP_SESSION_DOMAIN" envDefault:"localhost"`
+		HTTPSessionHTTPOnly   bool          `env:"HTTP_SESSION_HTTP_ONLY" envDefault:"true"`
+		HTTPSessionPath       string        `env:"HTTP_SESSION_PATH" envDefault:"/"`
+		HTTPSessionSameSite   http.SameSite `env:"HTTP_SESSION_SAME_SITE" envDefault:"1"`
+		HTTPSessionSecure     bool          `env:"HTTP_SESSION_SECURE" envDefault:"false"`
+		HTTPSessionSecrets    [][]byte      `env:"HTTP_SESSION_SECRETS,required" envDefault:""`
 
 		// Security related configuration.
 		HTTPAllowedHosts            []string          `env:"HTTP_ALLOWED_HOSTS" envDefault:""`
@@ -73,6 +75,7 @@ type (
 		HTTPCSRFCookieMaxAge        int               `env:"HTTP_CSRF_COOKIE_MAX_AGE" envDefault:"0"`
 		HTTPCSRFCookieName          string            `env:"HTTP_CSRF_COOKIE_NAME" envDefault:"_csrf_token"`
 		HTTPCSRFCookiePath          string            `env:"HTTP_CSRF_COOKIE_PATH" envDefault:"/"`
+		HTTPCSRFCookieSameSite      http.SameSite     `env:"HTTP_CSRF_COOKIE_SAME_SITE" envDefault:"1"`
 		HTTPCSRFCookieSecure        bool              `env:"HTTP_CSRF_COOKIE_SECURE" envDefault:"false"`
 		HTTPCSRFFieldName           string            `env:"HTTP_CSRF_FIELD_NAME" envDefault:"authenticity_token"`
 		HTTPCSRFRequestHeader       string            `env:"HTTP_CSRF_REQUEST_HEADER" envDefault:"X-CSRF-Token"`

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/fatih/camelcase v1.0.0
 	github.com/gin-contrib/multitemplate v0.0.0-20191128031210-95dee0dedf35
 	github.com/gin-contrib/sessions v0.0.3
-	github.com/gin-gonic/gin v1.5.0
+	github.com/gin-gonic/gin v1.5.1-0.20200307022333-1d055af1bc15
 	github.com/go-pg/pg/v9 v9.1.3
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/gorilla/context v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.5.0 h1:fi+bqFAx/oLK54somfCtEZs9HeH1LHVoEPUgARpTqyc=
 github.com/gin-gonic/gin v1.5.0/go.mod h1:Nd6IXA8m5kNZdNEHMBd93KT+mdY3+bewLgRvmCsR2Do=
+github.com/gin-gonic/gin v1.5.1-0.20200307022333-1d055af1bc15 h1:clzdpxhL8Q5KY0xVyQeX62s1R6enbbpG7WRE0db5BGc=
+github.com/gin-gonic/gin v1.5.1-0.20200307022333-1d055af1bc15/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-chi/chi v3.3.2+incompatible/go.mod h1:eB3wogJHnLi3x/kFX2A+IbTBlXxmMeXJVKy9tTv1XzQ=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -82,10 +84,18 @@ github.com/go-pg/urlstruct v0.3.0 h1:ORiTb205uT7v7lvq4VUOQ4ddJ5TjFRlVRWqWsMBgek4
 github.com/go-pg/urlstruct v0.3.0/go.mod h1:/XKyiUOUUS3onjF+LJxbfmSywYAdl6qMfVbX33Q8rgg=
 github.com/go-pg/zerochecker v0.1.1 h1:av77Qe7Gs+1oYGGh51k0sbZ0bUaxJEdeP0r8YE64Dco=
 github.com/go-pg/zerochecker v0.1.1/go.mod h1:NJZ4wKL0NmTtz0GKCoJ8kym6Xn/EQzXRl2OnAe7MmDo=
+github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
+github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.12.1 h1:2FITxuFt/xuCNP1Acdhv62OzaCiviiE4kotfhkmOqEc=
 github.com/go-playground/locales v0.12.1/go.mod h1:IUMDtCfWo/w/mtMfIE/IG2K+Ey3ygWanZIBtBW0W2TM=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
+github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
 github.com/go-playground/universal-translator v0.16.0 h1:X++omBR/4cE2MNg91AoC3rmGrCjJ8eAeUP/K/EKx4DM=
 github.com/go-playground/universal-translator v0.16.0/go.mod h1:1AnU7NaIRDWWzGEKwgtJRd2xk99HeFyHw3yid4rvQIY=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
+github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.2.0 h1:KgJ0snyC2R9VXYN2rneOtQcw5aHQB1Vv0sFl1UcHBOY=
+github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GOhaH6EGOAJShg8Id5JGkI=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee h1:s+21KNqlpePfkah2I+gwHF8xmJWRjooY+5248k6m4A0=
 github.com/gobwas/httphead v0.0.0-20180130184737-2c6c146eadee/go.mod h1:L0fX3K22YWvt/FAX9NnzrNzcI4wNYi9Yku4O0LKYflo=
@@ -144,6 +154,8 @@ github.com/jordan-wright/email v0.0.0-20190819015918-041e0cec78b0 h1:9RqhD4eIjDT
 github.com/jordan-wright/email v0.0.0-20190819015918-041e0cec78b0/go.mod h1:1c7szIrayyPPB/987hsnvNzLushdWf4o/79s3P08L8A=
 github.com/json-iterator/go v1.1.7 h1:KfgG9LzI+pYjr4xvmz/5H4FXjokeP+rlHLhv3iH62Fo=
 github.com/json-iterator/go v1.1.7/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/json-iterator/go v1.1.9 h1:9yzud/Ht36ygwatGx56VwCZtlI/2AD15T1X2sjSuGns=
+github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kidstuff/mongostore v0.0.0-20181113001930-e650cd85ee4b/go.mod h1:g2nVr8KZVXJSS97Jo8pJ0jgq29P6H7dG0oplUA86MQw=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -161,6 +173,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/leodido/go-urn v1.1.0 h1:Sm1gr51B1kKyfD2BlRcLSiEkffoG96g6TPv6eRoEiB8=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
+github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/mailru/easyjson v0.7.0 h1:aizVhC/NAAcKWb+5QsU1iNOZb4Yws5UO2I+aIprQITM=

--- a/internal/sessionstore/cookie.go
+++ b/internal/sessionstore/cookie.go
@@ -21,6 +21,7 @@ func (s *CookieStore) Options(options ginsessions.Options) {
 		Path:     options.Path,
 		Domain:   options.Domain,
 		MaxAge:   options.MaxAge,
+		SameSite: options.SameSite,
 		Secure:   options.Secure,
 		HttpOnly: options.HttpOnly,
 	}

--- a/internal/sessionstore/redis.go
+++ b/internal/sessionstore/redis.go
@@ -118,6 +118,7 @@ func (s *RedisStore) Options(options ginsessions.Options) {
 		Path:     options.Path,
 		Domain:   options.Domain,
 		MaxAge:   options.MaxAge,
+		SameSite: options.SameSite,
 		Secure:   options.Secure,
 		HttpOnly: options.HttpOnly,
 	}

--- a/mdw_csrf.go
+++ b/mdw_csrf.go
@@ -257,6 +257,7 @@ func saveCSRFTokenIntoCookie(token []byte, c *Context, config *Config) error {
 		config.HTTPCSRFCookieMaxAge,
 		config.HTTPCSRFCookiePath,
 		config.HTTPCSRFCookieDomain,
+		config.HTTPCSRFCookieSameSite,
 		config.HTTPCSRFCookieSecure,
 		config.HTTPCSRFCookieHTTPOnly,
 	)
@@ -271,6 +272,7 @@ func saveAuthenticityTokenIntoCookie(token string, c *Context, config *Config) {
 		config.HTTPCSRFCookieMaxAge,
 		config.HTTPCSRFCookiePath,
 		config.HTTPCSRFCookieDomain,
+		config.HTTPCSRFCookieSameSite,
 		config.HTTPCSRFCookieSecure,
 		false,
 	)

--- a/mdw_session_manager.go
+++ b/mdw_session_manager.go
@@ -142,6 +142,7 @@ func newSessionStore(config *Config) (SessionStore, error) {
 			MaxAge:   config.HTTPSessionExpiration,
 			Path:     config.HTTPSessionPath,
 			Secure:   config.HTTPSessionSecure,
+			SameSite: config.HTTPSessionSameSite,
 		})
 	}
 
@@ -219,6 +220,7 @@ func (s *Session) Options(options ginsessions.Options) {
 		Path:     options.Path,
 		Domain:   options.Domain,
 		MaxAge:   options.MaxAge,
+		SameSite: options.SameSite,
 		Secure:   options.Secure,
 		HttpOnly: options.HttpOnly,
 	}


### PR DESCRIPTION
This PR is to add `SameSite` attribute for both CSRF and session cookies. For more information on how this could help to further strengthen cookie's security, please refer to this [article](https://web.dev/samesite-cookies-explained/).