### PR TITLE
feat(orm): allow model object stubbing

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -1,6 +1,8 @@
 package mock
 
 import (
+	"reflect"
+
 	record "github.com/appist/appy/record"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -47,10 +49,15 @@ func NewDB() (func(name string) record.DBer, *DB) {
 }
 
 // NewModel initializes a test model that is useful for testing purpose.
-func NewModel() (func(dest interface{}, opts ...record.ModelOption) record.Modeler, *Model) {
+func NewModel(mockedDest interface{}) (func(dest interface{}, opts ...record.ModelOption) record.Modeler, *Model) {
 	m := &Model{}
 
 	return func(dest interface{}, opts ...record.ModelOption) record.Modeler {
+		if mockedDest != nil {
+			val := reflect.ValueOf(dest)
+			val.Elem().Set(reflect.ValueOf(mockedDest).Elem())
+		}
+
 		return m
 	}, m
 }


### PR DESCRIPTION
This PR is to further improve the ORM which will allow us to stub our own fake model object without hitting the DB at all.

Model Definition
```go
package model

import (
	"github.com/appist/appy/record"
	"github.com/appist/appy/support"
)

type User struct {
	record.Model                         `masters:"primary"`
	ID                   support.ZInt64  `db:"id" json:"id"`
	Username             support.ZString `db:"username" json:"username"`
}
```

HTTP Handler Implementation
```go
package handler

import (
	"<MODULE>/pkg/app"
	"<MODULE>/pkg/model"
	"net/http"

	"github.com/appist/appy/pack"
	"github.com/appist/appy/support"
)

func init() {
  // Define route with its handler.
  app.Server.GET("/users", userShow)
}

func userShow(c *pack.Context) {
  var user model.User

  // Find the user record with `username` equals to `foo` and load the found record into `user`.
  _, errs := app.Model(&user).Where("username = ?", "foo").Find().Exec()

  if errs != nil {
    c.JSON(http.StatusBadRequest, support.H{"error": errs[0].Error()})
    return
  }

  c.JSON(http.StatusOK, user)
}
```

HTTP Handler Unit Test
```go
package handler

import (
	"<MODULE>/pkg/app"
	"<MODULE>/pkg/model"
	"errors"
	"net/http/httptest"
	"testing"

	"github.com/appist/appy/mock"
	"github.com/appist/appy/pack"
	"github.com/appist/appy/support"
	"github.com/appist/appy/test"
)

func TestUserShow(t *testing.T) {
  // Swap the app.Logger so that we don't see too many redundant message in unit tests.
  appLogger := app.Logger
  app.Logger, _, _ = support.NewTestLogger()

  // Prepare to swap the app.Model exact implementation which we will use the mocked version later.
  var m *mock.Model
  appModel := app.Model

  defer func() {
    app.Logger = appLogger
    app.Model = appModel
  }()

  // Test #1: when `app.Model(&user).Where("username = ?", "foo").Find().Exec()` returns `user not found` error.
  {
    // Swap in the mocked `NewModel()` implementation.
    app.Model, m = mock.NewModel(nil)

    // Ensure we return `user not found` error.
    m.On("Where", "username = ?", "foo").Return(m).On("Find").Return(m).On("Exec").Return(int64(0), []error{errors.New("user not found")})

    // Initialise the HTTP response recorder.
    w := httptest.NewRecorder()
    
    // Initialise the HTTP test context.
    c, _ := pack.NewTestContext(w)

    // Pass the HTTP test context into the HTTP handler.
    userShow(c)
   
    // Assert if all our mocks are called as expected.
    m.AssertExpectations(t)

    // Assert if the HTTP response body equals to `{"error":"user not found"}`.
    assert := test.NewAssert(t)
    assert.Equal(`{"error":"user not found"}`, w.Body.String())
  }

  // Test #2: when `app.Model(&user).Where("username = ?", "foo").Find().Exec()` loads the user from database successfully.
  {
    // Swap in the mocked `NewModel()` implementation and ensure the model is loaded with a fake `model.User` object.
    app.Model, m = mock.NewModel(&model.User{ID: support.NewZInt64(1), Username: support.NewZString("foo")})

    // Ensure we return no error.
    m.On("Where", "username = ?", "foo").Return(m).On("Find").Return(m).On("Exec").Return(int64(1), nil)

    // Initialise the HTTP response recorder.
    w := httptest.NewRecorder()

    // Initialise the HTTP test context.
    c, _ := pack.NewTestContext(w)

    // Pass the HTTP test context into the HTTP handler.
    userShow(c)

    // Assert if all our mocks are called as expected.
    m.AssertExpectations(t)

    // Assert if the HTTP response body equals to `{"id":1,"username":"foo"}`.
    assert := test.NewAssert(t)
    assert.Equal(`{"id":1,"username":"foo"}`, w.Body.String())
  }
}
```