### PR TITLE
mock: remove aliases to types being deprecated in Testify

### DIFF
--- a/mock/mock.go
+++ b/mock/mock.go
@@ -12,14 +12,6 @@ type (
 	Mock struct {
 		mock.Mock
 	}
-
-	// AnythingOfTypeArgument is a string that contains the type of an argument
-	// for use when type checking.
-	AnythingOfTypeArgument = mock.AnythingOfTypeArgument
-
-	// IsTypeArgument is a struct that contains the type of an argument for use
-	// when type checking. This is an alternative to AnythingOfType.
-	IsTypeArgument = mock.IsTypeArgument
 )
 
 const (


### PR DESCRIPTION
The [Testify project](https://github.com/stretchr/testify/mock) has unfortunately exposed types [`AnythingOfTypeArgument`](https://pkg.go.dev/github.com/stretchr/testify/mock#AnythingOfTypeArgument) and [`IsTypeArgument`](https://pkg.go.dev/github.com/stretchr/testify/mock#IsTypeArgument) which should have stayed implementation details. They should have been private types hidden behind an interface.
Those types have function constructors that must be used instead:
* `mock.AnythingOfTypeArgument("string")` -> [`mock.AnythingOfType("string")`](https://pkg.go.dev/github.com/stretchr/testify/mock#AnythingOfType)
* `*mock.IsTypeArgument` -> [`mock.IsType`](https://pkg.go.dev/github.com/stretchr/testify/mock#IsType)

The references to those concrete types in downstream projects are blocking the cleanup of the Testify API.

appy/mock unfortunately propagate those mistakes. The appy project contains the only public reference to mock.IsTypeArgument on the whole GitHub: https://github.com/search?q=mock.IsTypeArgument+language%3Ago&type=code

... but it is not used beyond being exposed on the appy/mock package.

So this patch just deletes the two references to `AnythingOfTypeArgument` and `IsTypeArgument` in package `mock`.

Note: I'm a co-maintainer of the Testify project.